### PR TITLE
adding site_url value for chatbot

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: FarmShare
-
+site_url: https://docs.farmshare.stanford.edu/
 theme: readthedocs
 
 extra_css:


### PR DESCRIPTION
The documentation chatbot needs a base url in mkdocs.yml to build links.